### PR TITLE
Stop skipping SponsorBlock filler segments

### DIFF
--- a/src/lib/sponsorblock.ts
+++ b/src/lib/sponsorblock.ts
@@ -1,5 +1,5 @@
 const API_BASE = 'https://sponsor.ajay.app'
-const CATEGORIES = ['sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview', 'filler']
+const CATEGORIES = ['sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview']
 
 export interface SponsorSegment {
   segment: [number, number]
@@ -43,7 +43,6 @@ export function getCategoryLabel(category: string): string {
     intro: 'intro',
     outro: 'outro',
     preview: 'preview',
-    filler: 'filler',
   }
   return labels[category] || category
 }


### PR DESCRIPTION
Only skip actual ads/sponsors and the other intentional categories;
remove 'filler' from the fetched/skipped categories so tangents and
non-promotional asides are no longer auto-skipped.